### PR TITLE
Replace app.require to regular require where it possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HBase
 
-Plugin to enable Apache HBase server as a target in [Hackolade](https://hackolade.com) data modeling.  Requires prior download of the Hackolade application from our [download page](https://hackolade.com/download.html)
+Plugin to enable Apache HBase server as a target in [Hackolade](https://hackolade.com) data modeling.  Requires prior download of the Hackolade application from our [download page](https://hackolade.com/download.html
 
 Hackolade exposes its core data modeling engine through a plugin architecture.  Each plugin applies the Hackolade data modeling capabilities to a specific target technology, whether for data-at-rest (databases) or data-in-motion (communications.)  Each plugin matches the specific aspects of the target in terms of terminology, storage model, data types, and communication protocol.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HBase
 
-Plugin to enable Apache HBase server as a target in [Hackolade](https://hackolade.com) data modeling.  Requires prior download of the Hackolade application from our [download page](https://hackolade.com/download.html
+Plugin to enable Apache HBase server as a target in [Hackolade](https://hackolade.com) data modeling.  Requires prior download of the Hackolade application from our [download page](https://hackolade.com/download.html)
 
 Hackolade exposes its core data modeling engine through a plugin architecture.  Each plugin applies the Hackolade data modeling capabilities to a specific target technology, whether for data-at-rest (databases) or data-in-motion (communications.)  Each plugin matches the specific aspects of the target in terms of terminology, storage model, data types, and communication protocol.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
 	"name": "HBase",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "HBase",
-			"version": "0.1.16",
+			"version": "0.1.17",
 			"dependencies": {
+				"async": "^3.2.4",
 				"node-fetch": "2.7.0"
 			},
 			"devDependencies": {
-				"@hackolade/hck-esbuild-plugins-pack": "^0.0.1",
+				"@hackolade/hck-esbuild-plugins-pack": "0.0.1",
 				"esbuild": "0.19.2",
-				"esbuild-plugin-clean": "^1.0.1",
+				"esbuild-plugin-clean": "1.0.1",
 				"eslint": "8.48.0",
 				"eslint-config-prettier": "9.0.0",
 				"eslint-plugin-prettier": "5.0.0",
@@ -659,6 +660,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -3202,6 +3208,11 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
+		},
+		"async": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"package": "node esbuild.package.js"
 	},
 	"dependencies": {
+		"async": "^3.2.4",
 		"node-fetch": "2.7.0"
 	},
 	"devDependencies": {

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -2,6 +2,7 @@
 
 const https = require('https');
 const fs = require('fs');
+const async = require('async');
 const fetch = require('node-fetch');
 const versions = require('../package.json').contributes.target.versions;
 const colFamConfig = require('./columnFamilyConfig');
@@ -81,8 +82,6 @@ module.exports = {
 	},
 
 	getDbCollectionsNames: function (connectionInfo, logger, cb, app) {
-		const async = app.require('async');
-
 		logger.clear();
 
 		this.connect(
@@ -132,7 +131,6 @@ module.exports = {
 	},
 
 	getDbCollectionsData: function (data, logger, cb, app) {
-		const async = app.require('async');
 		let { recordSamplingSettings, fieldInference, includeEmptyCollection } = data;
 		let namespaces = data.collectionData.dataBaseNames;
 		let info = {


### PR DESCRIPTION
FYI: The `app.require('kerberos')` is still present in the HBase plugin until we replace it with another module.  